### PR TITLE
New features from Jeff Lang

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -1,4 +1,12 @@
 ﻿/*
+ *  ARO Information Icon CSS
+*/
+i.AROHoverIcon {
+	font-size: 36px;
+	color: blue
+}
+
+/*
     Styles for the datepicker in the Request Offering Toolbox.
 	These are required so that the date picker matches the date time picker on the forms.
 */


### PR DESCRIPTION
 - changed the app.events.unsubscribe to unsubscribe the correct item, this appears to have been left as drawerCreated after the change to subscribing to sessionStorageReady

- added back the modifications for the 2 pass adding of Criteria, this seems to have been missed in the last ones put up by @john_doyle

- Forced the previous sorting to sort via "DisplayName" as mentioned by @Brian_Winter

- Added new "@SingleLineEntry" option, placed before any text entry control, this will stop the control accepting Enter/CR into the field, resulting in a single line entry. (good to force on things like names or other items that should not have multiple lines)

- added new "AddInformation" entry, which results in either an icon or data added to the right of the next field (detailed below)

The @AddInformation control can accept 1 of 2 attributes,
if you wish to show an icon, and when the mouse if hovering over the icon the information entered is added to the page
to do this you need to pass the data to add to the page via an arg called "icon" eg

`@AddInformation {"icon":"&lt;p&gt;Text or formatting here&lt;br&gt;even multiple lines&lt;/p&gt"}`

if you do not wish the icon, but want the information added to the page always, then pass it as a arg called "info" eg

`@AddInformation {"info":"&lt;p&gt;Text or formatting here&lt;br&gt;even multiple lines&lt;/p&gt"`